### PR TITLE
Support constraints such as $1 \le 2$

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ mypy:
 	poetry run mypy --strict .
 
 ruff-lint:
-	poetry run ruff check .
+	poetry run ruff check --fix .
 
 ruff-format:
 	poetry run ruff format .

--- a/modeler.py
+++ b/modeler.py
@@ -248,11 +248,16 @@ class LPInequality:
 
 class LPModel:
     def __init__(self) -> None:
+        self.has_impossible_constraints = False
         self.constraints: list[LPInequality] = []
         self.objective: LPExpression = LPExpression(0, [])
 
-    def add_constraint(self, constraint: LPInequality) -> None:
-        self.constraints.append(constraint)
+    def add_constraint(self, constraint: LPInequality | bool) -> None:
+        if isinstance(constraint, bool):
+            if not constraint:
+                self.has_impossible_constraints = True
+        else:
+            self.constraints.append(constraint)
 
     def set_objective(self, objective: LPExpressionLike) -> None:
         self.objective = LPExpression.build(objective)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,4 +1,6 @@
-from modeler import LPModel, LPVar
+import pytest
+
+from modeler import LPModel, LPStatus, LPVar
 
 
 def test_simple_lp() -> None:
@@ -29,3 +31,34 @@ def test_simple_lp_nonnegative() -> None:
     model.set_objective(x + y)
 
     model.solve()
+
+
+def test_identity_constraint_feasible() -> None:
+    x = LPVar("x")
+
+    model = LPModel()
+
+    model.add_constraint(x <= 9.7)
+    model.add_constraint(3 <= 5)
+
+    model.set_objective(-x)
+
+    model.solve()
+
+    assert model.status == LPStatus.OPTIMAL
+    assert x.value() == pytest.approx(9.7)
+
+
+def test_identity_constraint_infeasible() -> None:
+    x = LPVar("x")
+
+    model = LPModel()
+
+    model.add_constraint(6 <= 5)
+
+    model.set_objective(x)
+
+    model.solve()
+
+    assert model.status == LPStatus.INFEASIBLE
+    assert x.value() is None


### PR DESCRIPTION
- [consider identity constraint · hitonanode/linprog-modeler@f5ecc67](https://github.com/hitonanode/linprog-modeler/commit/f5ecc6780fd8db79d1eea86b7f0382948f0cf353) : `Model.add_constraint()` accepts constraints like $1 \le 2$
- [add LPModel.status · hitonanode/linprog-modeler@0fc97b2](https://github.com/hitonanode/linprog-modeler/commit/0fc97b29e75d9e07143596fae421d6a5feeb65f3) : Create `LPStatus` enum class
- [add testcases for number-to-number inequality · hitonanode/linprog-modeler@4cf82fb](https://github.com/hitonanode/linprog-modeler/commit/4cf82fb8c318fa5e67ac1fc63ece0c4226c7342c) : add tests
- [fix Makefile · hitonanode/linprog-modeler@0bcb91a](https://github.com/hitonanode/linprog-modeler/commit/0bcb91a50f97b1734426a0fc5df2a449cd679e4a) : tiny fix